### PR TITLE
string syntax fix

### DIFF
--- a/publish-package/action.yml
+++ b/publish-package/action.yml
@@ -43,7 +43,7 @@ runs:
 
       - name: Publish distribution package to PyPI (production)
         uses: pypa/gh-action-pypi-publish@release/v1
-        if: inputs.debug_mode == 'false' && env.ACT != 'true'
+        if: inputs.debug_mode == 'false'
         with:
           password: ${{ inputs.pypi_api_token }}
           packages-dir: ${{ inputs.package_dir }}

--- a/publish-package/action.yml
+++ b/publish-package/action.yml
@@ -43,7 +43,7 @@ runs:
 
       - name: Publish distribution package to PyPI (production)
         uses: pypa/gh-action-pypi-publish@release/v1
-        if: ${{ !env.ACT || inputs.debug_mode == "false" }}
+        if: ${{ !env.ACT || inputs.debug_mode == false }}
         with:
           password: ${{ inputs.pypi_api_token }}
           packages-dir: ${{ inputs.package_dir }}

--- a/publish-package/action.yml
+++ b/publish-package/action.yml
@@ -43,7 +43,7 @@ runs:
 
       - name: Publish distribution package to PyPI (production)
         uses: pypa/gh-action-pypi-publish@release/v1
-        if: ${{ !env.ACT || inputs.debug_mode == false }}
+        if: inputs.debug_mode == 'false' && env.ACT != 'true'
         with:
           password: ${{ inputs.pypi_api_token }}
           packages-dir: ${{ inputs.package_dir }}


### PR DESCRIPTION
This PR fixes the bug in the if condition's string input syntax. Since the expression inside '${{ }}' is evaluated as string, the input value should not be given in quotation marks. 