### PR TITLE
condition is added to test pypi publish

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -62,6 +62,6 @@ jobs:
       - name: Test the publish-package action
         uses: ./publish-package
         with:
-          debug_mode: "true"
+          test_pypi: "true"
           test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
           pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}

--- a/publish-package/action.yml
+++ b/publish-package/action.yml
@@ -27,7 +27,7 @@ inputs:
     description: "Directory where the package distributions are stored."
     default: "./artifact"
   test_pypi:
-    description: "Parameter to skip publishing the package to official PyPI when set to 'true'"
+    description: "Parameter to publish the package to Test PyPI when set to 'true', and to publish to official Pypi when set to 'false'."
     default: "false"
 
 runs:

--- a/publish-package/action.yml
+++ b/publish-package/action.yml
@@ -26,7 +26,7 @@ inputs:
   package_dir: 
     description: "Directory where the package distributions are stored."
     default: "./artifact"
-  debug_mode:
+  test_pypi:
     description: "Parameter to skip publishing the package to official PyPI when set to 'true'"
     default: "false"
 
@@ -37,14 +37,14 @@ runs:
       - name: Publish distribution package to PyPI (test)
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          if: inputs.debug_mode == 'true'
+          if: inputs.test_pypi == 'true'
           password: ${{ inputs.test_pypi_api_token }}
           repository-url: https://test.pypi.org/legacy/
           packages-dir: ${{ inputs.package_dir }}
 
       - name: Publish distribution package to PyPI (production)
         uses: pypa/gh-action-pypi-publish@release/v1
-        if: inputs.debug_mode == 'false'
+        if: inputs.test_pypi == 'false'
         with:
           password: ${{ inputs.pypi_api_token }}
           packages-dir: ${{ inputs.package_dir }}

--- a/publish-package/action.yml
+++ b/publish-package/action.yml
@@ -37,6 +37,7 @@ runs:
       - name: Publish distribution package to PyPI (test)
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          if: inputs.debug_mode == 'true'
           password: ${{ inputs.test_pypi_api_token }}
           repository-url: https://test.pypi.org/legacy/
           packages-dir: ${{ inputs.package_dir }}


### PR DESCRIPTION
Publishing the package to the test pypi platform twice is causing issues. In the old set-up, it does test the publishing process twice - one while testing, one while publishing to actual pypi. The test-publish action should be used while testing only. This newly added condition will ensure that. 