### PR TITLE
Reusable pypi publish workflow

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -61,9 +61,9 @@ jobs:
       - name: Download dist content
         uses: actions/download-artifact@v4
 
-      - name: Test the publish-package action
-        uses: ghga-de/gh-action-pypi/publish-package@v1.0.2
-        with:
-          test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}
-          test_pypi: ${{ inputs.test_pypi }}
+      # - name: Test the publish-package action
+      #   uses: ghga-de/gh-action-pypi/publish-package@v1.0.2
+      #   with:
+      #     test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
+      #     pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}
+      #     test_pypi: ${{ inputs.test_pypi }}

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -54,6 +54,7 @@ jobs:
           else
             echo 'versions=["3.9", "3.10", "3.11", "3.12"]' >> "$GITHUB_OUTPUT"
           fi
+          echo "$GITHUB_OUTPUT"  >&2
 
   test-package:
     name: Test Freshly Built Package

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -11,6 +11,11 @@ on:
         description: "Parameter to publish the package to Test PyPI when set to 'true', and to publish to official Pypi when set to 'false'."
         type: string
         required: true
+      python_latest:
+        description: 'Use the latest Python version (3.12)'
+        required: true
+        default: false
+        type: boolean
 
 jobs:
 
@@ -28,7 +33,7 @@ jobs:
           tag: ${{ inputs.package_version }}
 
       - name: Build Python Package
-        uses: ghga-de/gh-action-pypi/build-python-package@v1.1.2
+        uses: ghga-de/gh-action-pypi/build-python-package@main
 
       - name: Upload package artifact
         uses: actions/upload-artifact@v4
@@ -41,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout repository 
@@ -49,9 +54,16 @@ jobs:
 
       - name: Download dist content
         uses: actions/download-artifact@v4
+      
+      - name: Test with Python 3.12 using the test-package action
+        if: ${{ inputs.python_latest }}
+        uses: ghga-de/gh-action-pypi/test-package@main
+        with:
+          python_version: 3.12
 
-      - name: Test using the test-package action
-        uses: ghga-de/gh-action-pypi/test-package@v1.1.2
+      - name: Test with Python 3.9-3.12 using the test-package action
+        if: ${{ !inputs.python_latest }}
+        uses: ghga-de/gh-action-pypi/test-package@main
         with:
           python_version: ${{ matrix.python-version }}
 
@@ -68,7 +80,7 @@ jobs:
         uses: actions/download-artifact@v4
 
       - name: Publish using the publish-package action
-        uses: ghga-de/gh-action-pypi/publish-package@v1.1.2
+        uses: ghga-de/gh-action-pypi/publish-package@main
         with:
           test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
           pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -40,37 +40,37 @@ jobs:
         with:
           path: ./dist
 
+  define-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: $
+    steps:
+      - name: Define python versions
+        run: |
+        PYTHON_LATEST=${{ inputs.python_latest }}
+        if $PYTHON_LATEST; then 
+          echo '["3.12"]' >> "$GITHUB_OUTPUT"
+        else
+          echo '["3.9", "3.10", "3.11", "3.12"]' >> "$GITHUB_OUTPUT"
+        fi
+
   test-package:
     name: Test Freshly Built Package
-    needs: build-package
+    needs:
+    - build-package
+    - define-matrix
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_latest: [true, false]
-        python-version: [3.9, 3.10, 3.11, 3.12]
-        exclude:
-          - python_latest: true
-            python-version: 3.9
-          - python_latest: true
-            python-version: 3.10
-          - python_latest: true
-            python-version: 3.11
-
+        python-version: ${{ fromJSON(needs.define-matrix.outputs.versions) }}
     steps:
       - name: Checkout repository 
         uses: actions/checkout@v4
 
       - name: Download dist content
         uses: actions/download-artifact@v4
-      
-      # - name: Test with Python 3.12 using the test-package action
-      #   if: ${{ inputs.python_latest }}
-      #   uses: ghga-de/gh-action-pypi/test-package@main
-      #   with:
-      #     python_version: 3.12
 
       - name: Test using the test-package action
-        if: ${{ !inputs.python_latest }}
         uses: ghga-de/gh-action-pypi/test-package@main
         with:
           python_version: ${{ matrix.python-version }}

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -46,8 +46,8 @@ jobs:
       versions: $
     steps:
       - name: Define python versions
+        shell: bash
         run: |
-        echo ${{ inputs.python_latest }} >&2
         PYTHON_LATEST=${{ inputs.python_latest }}
         if $PYTHON_LATEST; then 
           echo '["3.12"]' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Download dist content
         uses: actions/download-artifact@v4
 
-      - name: Test the test-package action
+      - name: Test using the test-package action
         uses: ghga-de/gh-action-pypi/test-package@v1.1.2
         with:
           python_version: ${{ matrix.python-version }}

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -47,6 +47,7 @@ jobs:
     steps:
       - name: Define python versions
         run: |
+        echo ${{ inputs.python_latest }} >&2
         PYTHON_LATEST=${{ inputs.python_latest }}
         if $PYTHON_LATEST; then 
           echo '["3.12"]' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -47,6 +47,8 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
+        include:
+        - python_latest: false
 
     steps:
       - name: Checkout repository 

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -6,8 +6,8 @@ on:
       package_version:
         description: "The version used to publish to the registry."
         required: true
-    #   test_pypi: "Parameter to publish the package to Test PyPI when set to 'true', and to publish to official Pypi when set to 'false'."
-    #     required: true
+      test_pypi: "Parameter to publish the package to Test PyPI when set to 'true', and to publish to official Pypi when set to 'false'."
+        required: true
 
 jobs:
 
@@ -61,9 +61,9 @@ jobs:
       - name: Download dist content
         uses: actions/download-artifact@v4
 
-      # - name: Test the publish-package action
-      #   uses: ghga-de/gh-action-pypi/publish-package@v1.0.2
-      #   with:
-      #     test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
-      #     pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}
-      #     test_pypi: ${{ inputs.test_pypi }}
+      - name: Test the publish-package action
+        uses: ghga-de/gh-action-pypi/publish-package@v1.0.2
+        with:
+          test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}
+          test_pypi: ${{ inputs.test_pypi }}

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -5,6 +5,7 @@ on:
     inputs:
       package_version:
         description: "The version used to publish to the registry."
+        type: string
         required: true
       # test_pypi:
       #   description: "Parameter to publish the package to Test PyPI when set to 'true', and to publish to official Pypi when set to 'false'."

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -44,7 +44,8 @@ jobs:
         python-version: ["3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository 
+        uses: actions/checkout@v4
 
       - name: Download dist content
         uses: actions/download-artifact@v4

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -2,13 +2,6 @@ name: PyPI publish
 
 on:
   workflow_call:
-    secrets:
-        TEST_PYPI_API_TOKEN:
-          description: "Token required to publish the package to test pypi"
-          required: true
-        PYPI_API_TOKEN:
-          description: "Token required to publish the package to pypi"
-          required: true
 
 jobs:
 

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -43,15 +43,16 @@ jobs:
   define-matrix:
     runs-on: ubuntu-latest
     outputs:
-      versions: $
+      versions: ${{ steps.version.outputs.python }}
     steps:
       - name: Define python versions
+        id: version
         run: |
           PYTHON_LATEST=${{ inputs.python_latest }}
           if $PYTHON_LATEST; then 
-            echo "versions=["3.12"]" >> "$GITHUB_OUTPUT"
+            echo 'python=["3.12"]' >> "$GITHUB_OUTPUT"
           else
-            echo 'versions=["3.9", "3.10", "3.11", "3.12"]' >> "$GITHUB_OUTPUT"
+            echo 'python=["3.9", "3.10", "3.11", "3.12"]' >> "$GITHUB_OUTPUT"
           fi
       
 
@@ -70,10 +71,6 @@ jobs:
 
       - name: Download dist content
         uses: actions/download-artifact@v4
-      
-      - name: Report version
-        run: |
-          cat python-version
 
       - name: Test using the test-package action
         uses: ghga-de/gh-action-pypi/test-package@main

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -2,10 +2,10 @@ name: PyPI publish
 
 on:
   workflow_call:
-    # inputs:
-    #   # package_version:
-    #   #   description: "The version used to publish to the registry."
-    #   #   required: true
+    inputs:
+      package_version:
+        description: "The version used to publish to the registry."
+        required: true
     #   test_pypi: "Parameter to publish the package to Test PyPI when set to 'true', and to publish to official Pypi when set to 'false'."
     #     required: true
 
@@ -18,18 +18,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # - name: Validate Version Tag
-      #   uses: ghga-de/gh-action-pypi/verify-version-tag@v1.0.2
-      #   with:
-      #     tag: ${{ inputs.package_version }}
+      - name: Validate Version Tag
+        uses: ghga-de/gh-action-pypi/verify-version-tag@v1.0.2
+        with:
+          tag: ${{ inputs.package_version }}
 
       - name: Build Python Package
         uses: ghga-de/gh-action-pypi/build-python-package@v1.0.2
 
-      - name: Upload package artifact
-        uses: actions/upload-artifact@v4
-        with:
-          path: ./dist
+      # - name: Upload package artifact
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     path: ./dist
 
   test-package:
     name: Test Freshly Built Package

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -2,6 +2,10 @@ name: PyPI publish
 
 on:
   workflow_call:
+    inputs:
+      package_version:
+        description: "The version used to publish to the registry."
+        required: true
 
 jobs:
 
@@ -15,7 +19,7 @@ jobs:
       - name: Validate Version Tag
         uses: ghga-de/gh-action-pypi/verify-version-tag@v1.0.1
         with:
-          tag: "1.2.1"
+          tag: ${{ inputs.package_version }}
 
       - name: Build Python Package
         uses: ghga-de/gh-action-pypi/build-python-package@v1.0.1

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -21,12 +21,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Validate Version Tag
-        uses: ./verify-version-tag
+        uses: ghga-de/gh-action-pypi/verify-version-tag@v1.1.0
         with:
           tag: ${{ inputs.package_version }}
 
       - name: Build Python Package
-        uses: ./build-python-package
+        uses: ghga-de/gh-action-pypi/build-python-package@v1.1.0
 
       - name: Upload package artifact
         uses: actions/upload-artifact@v4
@@ -48,7 +48,7 @@ jobs:
         uses: actions/download-artifact@v4
 
       - name: Test the test-package action
-        uses: ./test-package
+        uses: ghga-de/gh-action-pypi/test-package@v1.1.0
         with:
           python_version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -3,9 +3,9 @@ name: PyPI publish
 on:
   workflow_call:
     inputs:
-      package_version:
-        description: "The version used to publish to the registry."
-        required: true
+      # package_version:
+      #   description: "The version used to publish to the registry."
+      #   required: true
       test_pypi: "Parameter to publish the package to Test PyPI when set to 'true', and to publish to official Pypi when set to 'false'."
         required: true
 
@@ -18,10 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Validate Version Tag
-        uses: ghga-de/gh-action-pypi/verify-version-tag@v1.0.2
-        with:
-          tag: ${{ inputs.package_version }}
+      # - name: Validate Version Tag
+      #   uses: ghga-de/gh-action-pypi/verify-version-tag@v1.0.2
+      #   with:
+      #     tag: ${{ inputs.package_version }}
 
       - name: Build Python Package
         uses: ghga-de/gh-action-pypi/build-python-package@v1.0.2
@@ -61,9 +61,9 @@ jobs:
       - name: Download dist content
         uses: actions/download-artifact@v4
 
-      # - name: Test the publish-package action
-      #   uses: ghga-de/gh-action-pypi/publish-package@v1.0.2
-      #   with:
-      #     test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
-      #     pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}
-      #     test_pypi: ${{ inputs.test_pypi }}
+      - name: Test the publish-package action
+        uses: ghga-de/gh-action-pypi/publish-package@v1.0.2
+        with:
+          test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}
+          test_pypi: ${{ inputs.test_pypi }}

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -26,10 +26,10 @@ jobs:
       - name: Build Python Package
         uses: ghga-de/gh-action-pypi/build-python-package@v1.0.2
 
-      # - name: Upload package artifact
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     path: ./dist
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          path: ./dist
 
   test-package:
     name: Test Freshly Built Package

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -2,12 +2,12 @@ name: PyPI publish
 
 on:
   workflow_call:
-    inputs:
-      # package_version:
-      #   description: "The version used to publish to the registry."
-      #   required: true
-      test_pypi: "Parameter to publish the package to Test PyPI when set to 'true', and to publish to official Pypi when set to 'false'."
-        required: true
+    # inputs:
+    #   # package_version:
+    #   #   description: "The version used to publish to the registry."
+    #   #   required: true
+    #   test_pypi: "Parameter to publish the package to Test PyPI when set to 'true', and to publish to official Pypi when set to 'false'."
+    #     required: true
 
 jobs:
 
@@ -61,9 +61,9 @@ jobs:
       - name: Download dist content
         uses: actions/download-artifact@v4
 
-      - name: Test the publish-package action
-        uses: ghga-de/gh-action-pypi/publish-package@v1.0.2
-        with:
-          test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}
-          test_pypi: ${{ inputs.test_pypi }}
+      # - name: Test the publish-package action
+      #   uses: ghga-de/gh-action-pypi/publish-package@v1.0.2
+      #   with:
+      #     test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
+      #     pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}
+      #     test_pypi: ${{ inputs.test_pypi }}

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,0 +1,70 @@
+name: PyPI publish
+
+on:
+  workflow_call:
+    secrets:
+        TEST_PYPI_API_TOKEN:
+          description: "Token required to publish the package to test pypi"
+          required: true
+        PYPI_API_TOKEN:
+          description: "Token required to publish the package to pypi"
+          required: true
+
+jobs:
+
+  build-package:
+    name: Build Package with Verified Version
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate Version Tag
+        uses: ghga-de/gh-action-pypi/verify-version-tag@v1.0.1
+        with:
+          tag: "1.2.1"
+
+      - name: Build Python Package
+        uses: ghga-de/gh-action-pypi/build-python-package@v1.0.1
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          path: ./dist
+
+  test-package:
+    name: Test Freshly Built Package
+    needs: build-package
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download dist content
+        uses: actions/download-artifact@v4
+
+      - name: Test the test-package action
+        uses: ghga-de/gh-action-pypi/test-package@v1.0.1
+        with:
+          python_version: ${{ matrix.python-version }}
+
+  publish-package:
+    name: Publish Package
+    needs: test-package
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download dist content
+        uses: actions/download-artifact@v4
+
+      - name: Test the publish-package action
+        uses: ghga-de/gh-action-pypi/publish-package@v1.0.1
+        with:
+          test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}
+          debug_mode: 'true'

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -50,9 +50,9 @@ jobs:
         run: |
           PYTHON_LATEST=${{ inputs.python_latest }}
           if $PYTHON_LATEST; then 
-            echo '["3.12"]' >> "$GITHUB_OUTPUT"
+            echo 'versions=["3.12"]' >> "$GITHUB_OUTPUT"
           else
-            echo '["3.9", "3.10", "3.11", "3.12"]' >> "$GITHUB_OUTPUT"
+            echo 'versions=["3.9", "3.10", "3.11", "3.12"]' >> "$GITHUB_OUTPUT"
           fi
 
   test-package:

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -21,12 +21,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Validate Version Tag
-        uses: ghga-de/gh-action-pypi/verify-version-tag@v1.0.2
+        uses: ./verify-version-tag
         with:
           tag: ${{ inputs.package_version }}
 
       - name: Build Python Package
-        uses: ghga-de/gh-action-pypi/build-python-package@v1.0.2
+        uses: ./build-python-package
 
       - name: Upload package artifact
         uses: actions/upload-artifact@v4
@@ -48,7 +48,7 @@ jobs:
         uses: actions/download-artifact@v4
 
       - name: Test the test-package action
-        uses: ghga-de/gh-action-pypi/test-package@v1.0.2
+        uses: ./test-package
         with:
           python_version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -22,12 +22,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Validate Version Tag
-        uses: ghga-de/gh-action-pypi/verify-version-tag@v1.1.1
+        uses: ghga-de/gh-action-pypi/verify-version-tag@v1.1.2
         with:
           tag: ${{ inputs.package_version }}
 
       - name: Build Python Package
-        uses: ghga-de/gh-action-pypi/build-python-package@v1.1.1
+        uses: ghga-de/gh-action-pypi/build-python-package@v1.1.2
 
       - name: Upload package artifact
         uses: actions/upload-artifact@v4
@@ -49,7 +49,7 @@ jobs:
         uses: actions/download-artifact@v4
 
       - name: Test the test-package action
-        uses: ghga-de/gh-action-pypi/test-package@v1.1.1
+        uses: ghga-de/gh-action-pypi/test-package@v1.1.2
         with:
           python_version: ${{ matrix.python-version }}
 
@@ -65,7 +65,7 @@ jobs:
         uses: actions/download-artifact@v4
 
       - name: Test the publish-package action
-        uses: ghga-de/gh-action-pypi/publish-package@v1.1.1
+        uses: ghga-de/gh-action-pypi/publish-package@v1.1.2
         with:
           test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
           pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -61,7 +61,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository 
+        uses: actions/checkout@v4
 
       - name: Download dist content
         uses: actions/download-artifact@v4

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Validate Version Tag
-        uses: ghga-de/gh-action-pypi/verify-version-tag@v1.1.2
+        uses: ghga-de/gh-action-pypi/verify-version-tag
         with:
           tag: ${{ inputs.package_version }}
 

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -6,7 +6,8 @@ on:
       package_version:
         description: "The version used to publish to the registry."
         required: true
-      test_pypi: "Parameter to publish the package to Test PyPI when set to 'true', and to publish to official Pypi when set to 'false'."
+      test_pypi:
+        description: "Parameter to publish the package to Test PyPI when set to 'true', and to publish to official Pypi when set to 'false'."
         required: true
 
 jobs:
@@ -61,9 +62,9 @@ jobs:
       - name: Download dist content
         uses: actions/download-artifact@v4
 
-      # - name: Test the publish-package action
-      #   uses: ghga-de/gh-action-pypi/publish-package@v1.0.2
-      #   with:
-      #     test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
-      #     pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}
-      #     test_pypi: ${{ inputs.test_pypi }}
+      - name: Test the publish-package action
+        uses: ghga-de/gh-action-pypi/publish-package@v1.0.2
+        with:
+          test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}
+          test_pypi: ${{ inputs.test_pypi }}

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/download-artifact@v4
 
       - name: Test using the test-package action
-        uses: ghga-de/gh-action-pypi/test-package@reusable_publish_workflow
+        uses: ghga-de/gh-action-pypi/test-package@main
         with:
           python_version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Download dist content
         uses: actions/download-artifact@v4
 
-      - name: Test the publish-package action
+      - name: Publish using the publish-package action
         uses: ghga-de/gh-action-pypi/publish-package@v1.1.2
         with:
           test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -28,12 +28,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate Version Tag
-        uses: ghga-de/gh-action-pypi/verify-version-tag@c350d120fad0e7e6eef85cf513a267291b3f26b4
+        uses: ghga-de/gh-action-pypi/verify-version-tag@main
         with:
           tag: ${{ inputs.package_version }}
 
       - name: Build Python Package
-        uses: ghga-de/gh-action-pypi/build-python-package@c350d120fad0e7e6eef85cf513a267291b3f26b4
+        uses: ghga-de/gh-action-pypi/build-python-package@main
 
       - name: Upload package artifact
         uses: actions/upload-artifact@v4
@@ -57,13 +57,13 @@ jobs:
       
       - name: Test with Python 3.12 using the test-package action
         if: ${{ inputs.python_latest }}
-        uses: ghga-de/gh-action-pypi/test-package@c350d120fad0e7e6eef85cf513a267291b3f26b4
+        uses: ghga-de/gh-action-pypi/test-package@main
         with:
           python_version: 3.12
 
       - name: Test with Python 3.9-3.12 using the test-package action
         if: ${{ !inputs.python_latest }}
-        uses: ghga-de/gh-action-pypi/test-package@c350d120fad0e7e6eef85cf513a267291b3f26b4
+        uses: ghga-de/gh-action-pypi/test-package@main
         with:
           python_version: ${{ matrix.python-version }}
 
@@ -80,7 +80,7 @@ jobs:
         uses: actions/download-artifact@v4
 
       - name: Publish using the publish-package action
-        uses: ghga-de/gh-action-pypi/publish-package@c350d120fad0e7e6eef85cf513a267291b3f26b4
+        uses: ghga-de/gh-action-pypi/publish-package@main
         with:
           test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
           pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -6,6 +6,8 @@ on:
       package_version:
         description: "The version used to publish to the registry."
         required: true
+      test_pypi: "Parameter to publish the package to Test PyPI when set to 'true', and to publish to official Pypi when set to 'false'."
+        required: true
 
 jobs:
 
@@ -64,4 +66,4 @@ jobs:
         with:
           test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
           pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}
-          debug_mode: 'true'
+          test_pypi: ${{ inputs.test_pypi }}

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -9,6 +9,7 @@ on:
         required: true
       test_pypi:
         description: "Parameter to publish the package to Test PyPI when set to 'true', and to publish to official Pypi when set to 'false'."
+        type: string
         required: true
 
 jobs:

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -19,7 +19,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository 
+        uses: actions/checkout@v4
 
       - name: Validate Version Tag
         uses: ghga-de/gh-action-pypi/verify-version-tag@main

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -7,9 +7,9 @@ on:
         description: "The version used to publish to the registry."
         type: string
         required: true
-      # test_pypi:
-      #   description: "Parameter to publish the package to Test PyPI when set to 'true', and to publish to official Pypi when set to 'false'."
-      #   required: true
+      test_pypi:
+        description: "Parameter to publish the package to Test PyPI when set to 'true', and to publish to official Pypi when set to 'false'."
+        required: true
 
 jobs:
 
@@ -52,20 +52,20 @@ jobs:
         with:
           python_version: ${{ matrix.python-version }}
 
-  # publish-package:
-  #   name: Publish Package
-  #   needs: test-package
-  #   runs-on: ubuntu-latest
+  publish-package:
+    name: Publish Package
+    needs: test-package
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - uses: actions/checkout@v4
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - name: Download dist content
-  #       uses: actions/download-artifact@v4
+      - name: Download dist content
+        uses: actions/download-artifact@v4
 
-  #     - name: Test the publish-package action
-  #       uses: ghga-de/gh-action-pypi/publish-package@v1.0.2
-  #       with:
-  #         test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
-  #         pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}
-  #         test_pypi: ${{ inputs.test_pypi }}
+      - name: Test the publish-package action
+        uses: ghga-de/gh-action-pypi/publish-package@v1.0.2
+        with:
+          test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}
+          test_pypi: ${{ inputs.test_pypi }}

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/download-artifact@v4
 
       - name: Test using the test-package action
-        uses: ghga-de/gh-action-pypi/test-package@main
+        uses: ghga-de/gh-action-pypi/test-package@@reusable_publish_workflow
         with:
           python_version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -48,12 +48,12 @@ jobs:
       - name: Define python versions
         shell: bash
         run: |
-        PYTHON_LATEST=${{ inputs.python_latest }}
-        if $PYTHON_LATEST; then 
-          echo '["3.12"]' >> "$GITHUB_OUTPUT"
-        else
-          echo '["3.9", "3.10", "3.11", "3.12"]' >> "$GITHUB_OUTPUT"
-        fi
+          PYTHON_LATEST=${{ inputs.python_latest }}
+          if $PYTHON_LATEST; then 
+            echo '["3.12"]' >> "$GITHUB_OUTPUT"
+          else
+            echo '["3.9", "3.10", "3.11", "3.12"]' >> "$GITHUB_OUTPUT"
+          fi
 
   test-package:
     name: Test Freshly Built Package

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -21,12 +21,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Validate Version Tag
-        uses: ghga-de/gh-action-pypi/verify-version-tag@v1.1.0
+        uses: ghga-de/gh-action-pypi/verify-version-tag@v1.1.1
         with:
           tag: ${{ inputs.package_version }}
 
       - name: Build Python Package
-        uses: ghga-de/gh-action-pypi/build-python-package@v1.1.0
+        uses: ghga-de/gh-action-pypi/build-python-package@v1.1.1
 
       - name: Upload package artifact
         uses: actions/upload-artifact@v4
@@ -48,7 +48,7 @@ jobs:
         uses: actions/download-artifact@v4
 
       - name: Test the test-package action
-        uses: ghga-de/gh-action-pypi/test-package@v1.1.0
+        uses: ghga-de/gh-action-pypi/test-package@v1.1.1
         with:
           python_version: ${{ matrix.python-version }}
 
@@ -64,7 +64,7 @@ jobs:
         uses: actions/download-artifact@v4
 
       - name: Test the publish-package action
-        uses: ghga-de/gh-action-pypi/publish-package@v1.0.2
+        uses: ghga-de/gh-action-pypi/publish-package@v1.1.1
         with:
           test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
           pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -19,12 +19,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Validate Version Tag
-        uses: ghga-de/gh-action-pypi/verify-version-tag@v1.0.1
+        uses: ghga-de/gh-action-pypi/verify-version-tag@v1.0.2
         with:
           tag: ${{ inputs.package_version }}
 
       - name: Build Python Package
-        uses: ghga-de/gh-action-pypi/build-python-package@v1.0.1
+        uses: ghga-de/gh-action-pypi/build-python-package@v1.0.2
 
       - name: Upload package artifact
         uses: actions/upload-artifact@v4
@@ -46,7 +46,7 @@ jobs:
         uses: actions/download-artifact@v4
 
       - name: Test the test-package action
-        uses: ghga-de/gh-action-pypi/test-package@v1.0.1
+        uses: ghga-de/gh-action-pypi/test-package@v1.0.2
         with:
           python_version: ${{ matrix.python-version }}
 
@@ -62,7 +62,7 @@ jobs:
         uses: actions/download-artifact@v4
 
       - name: Test the publish-package action
-        uses: ghga-de/gh-action-pypi/publish-package@v1.0.1
+        uses: ghga-de/gh-action-pypi/publish-package@v1.0.2
         with:
           test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
           pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -28,12 +28,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate Version Tag
-        uses: ghga-de/gh-action-pypi/verify-version-tag@main
+        uses: ghga-de/gh-action-pypi/verify-version-tag@c350d120fad0e7e6eef85cf513a267291b3f26b4
         with:
           tag: ${{ inputs.package_version }}
 
       - name: Build Python Package
-        uses: ghga-de/gh-action-pypi/build-python-package@main
+        uses: ghga-de/gh-action-pypi/build-python-package@c350d120fad0e7e6eef85cf513a267291b3f26b4
 
       - name: Upload package artifact
         uses: actions/upload-artifact@v4
@@ -57,13 +57,13 @@ jobs:
       
       - name: Test with Python 3.12 using the test-package action
         if: ${{ inputs.python_latest }}
-        uses: ghga-de/gh-action-pypi/test-package@main
+        uses: ghga-de/gh-action-pypi/test-package@c350d120fad0e7e6eef85cf513a267291b3f26b4
         with:
           python_version: 3.12
 
       - name: Test with Python 3.9-3.12 using the test-package action
         if: ${{ !inputs.python_latest }}
-        uses: ghga-de/gh-action-pypi/test-package@main
+        uses: ghga-de/gh-action-pypi/test-package@c350d120fad0e7e6eef85cf513a267291b3f26b4
         with:
           python_version: ${{ matrix.python-version }}
 
@@ -80,7 +80,7 @@ jobs:
         uses: actions/download-artifact@v4
 
       - name: Publish using the publish-package action
-        uses: ghga-de/gh-action-pypi/publish-package@main
+        uses: ghga-de/gh-action-pypi/publish-package@c350d120fad0e7e6eef85cf513a267291b3f26b4
         with:
           test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
           pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/download-artifact@v4
 
       - name: Test using the test-package action
-        uses: ghga-de/gh-action-pypi/test-package@@reusable_publish_workflow
+        uses: ghga-de/gh-action-pypi/test-package@reusable_publish_workflow
         with:
           python_version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -53,7 +53,7 @@ jobs:
           else
             echo 'versions=["3.9", "3.10", "3.11", "3.12"]' >> "$GITHUB_OUTPUT"
           fi
-          echo "$GITHUB_OUTPUT"  >&2
+      
 
   test-package:
     name: Test Freshly Built Package
@@ -70,6 +70,10 @@ jobs:
 
       - name: Download dist content
         uses: actions/download-artifact@v4
+      
+      - name: Report version
+        run: |
+          cat python-version
 
       - name: Test using the test-package action
         uses: ghga-de/gh-action-pypi/test-package@main

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Validate Version Tag
-        uses: ghga-de/gh-action-pypi/verify-version-tag
+        uses: ghga-de/gh-action-pypi/verify-version-tag@main
         with:
           tag: ${{ inputs.package_version }}
 

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -46,9 +46,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
-        include:
-        - python_latest: false
+        python_latest: [true, false]
+        python-version: [3.9, 3.10, 3.11, 3.12]
+        exclude:
+          - python_latest: true
+            python-version: 3.9
+          - python_latest: true
+            python-version: 3.10
+          - python_latest: true
+            python-version: 3.11
 
     steps:
       - name: Checkout repository 
@@ -57,13 +63,13 @@ jobs:
       - name: Download dist content
         uses: actions/download-artifact@v4
       
-      - name: Test with Python 3.12 using the test-package action
-        if: ${{ inputs.python_latest }}
-        uses: ghga-de/gh-action-pypi/test-package@main
-        with:
-          python_version: 3.12
+      # - name: Test with Python 3.12 using the test-package action
+      #   if: ${{ inputs.python_latest }}
+      #   uses: ghga-de/gh-action-pypi/test-package@main
+      #   with:
+      #     python_version: 3.12
 
-      - name: Test with Python 3.9-3.12 using the test-package action
+      - name: Test using the test-package action
         if: ${{ !inputs.python_latest }}
         uses: ghga-de/gh-action-pypi/test-package@main
         with:

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -6,9 +6,9 @@ on:
       package_version:
         description: "The version used to publish to the registry."
         required: true
-      test_pypi:
-        description: "Parameter to publish the package to Test PyPI when set to 'true', and to publish to official Pypi when set to 'false'."
-        required: true
+      # test_pypi:
+      #   description: "Parameter to publish the package to Test PyPI when set to 'true', and to publish to official Pypi when set to 'false'."
+      #   required: true
 
 jobs:
 
@@ -51,20 +51,20 @@ jobs:
         with:
           python_version: ${{ matrix.python-version }}
 
-  publish-package:
-    name: Publish Package
-    needs: test-package
-    runs-on: ubuntu-latest
+  # publish-package:
+  #   name: Publish Package
+  #   needs: test-package
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v4
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - name: Download dist content
-        uses: actions/download-artifact@v4
+  #     - name: Download dist content
+  #       uses: actions/download-artifact@v4
 
-      - name: Test the publish-package action
-        uses: ghga-de/gh-action-pypi/publish-package@v1.0.2
-        with:
-          test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}
-          test_pypi: ${{ inputs.test_pypi }}
+  #     - name: Test the publish-package action
+  #       uses: ghga-de/gh-action-pypi/publish-package@v1.0.2
+  #       with:
+  #         test_pypi_api_token: ${{ secrets.TEST_PYPI_API_TOKEN }}
+  #         pypi_api_token: ${{ secrets.PYPI_API_TOKEN }}
+  #         test_pypi: ${{ inputs.test_pypi }}

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -46,11 +46,10 @@ jobs:
       versions: $
     steps:
       - name: Define python versions
-        shell: bash
         run: |
           PYTHON_LATEST=${{ inputs.python_latest }}
           if $PYTHON_LATEST; then 
-            echo 'versions=["3.12"]' >> "$GITHUB_OUTPUT"
+            echo "versions=["3.12"]" >> "$GITHUB_OUTPUT"
           else
             echo 'versions=["3.9", "3.10", "3.11", "3.12"]' >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -1,10 +1,10 @@
 name: Test PyPI Publish Workflow
 
-on: workflow_dispatch
+on: release
 
 jobs:
 
-  build_python_package:
+  build-python-package:
     name: Version Verified Package Build
     runs-on: ubuntu-latest
 
@@ -28,13 +28,34 @@ jobs:
         with:
           path: ./test/dummy-package/dist
 
-  test_package:
+
+  define-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.version.outputs.python }}
+    steps:
+      - name: Define python versions
+        id: version
+        with:
+          python_latest: false
+        run: |
+          PYTHON_LATEST=${{ inputs.python_latest }}
+          if $PYTHON_LATEST; then 
+            echo 'python=["3.12"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'python=["3.9", "3.10", "3.11", "3.12"]' >> "$GITHUB_OUTPUT"
+          fi
+
+
+  test-package:
     name: Test Python Package
-    needs: build_python_package
+    needs:
+    - build-python-package
+    - define-matrix
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ${{ fromJSON(needs.define-matrix.outputs.versions) }}
 
     steps:
       - uses: actions/checkout@v4
@@ -48,9 +69,9 @@ jobs:
           working_directory: ./test/dummy-package
           python_version: ${{ matrix.python-version }}
 
-  publish_package:
+  publish-package:
     name: Test Publish Package
-    needs: test_package
+    needs: test-package
     runs-on: ubuntu-latest
 
     steps:

--- a/build-python-package/action.yml
+++ b/build-python-package/action.yml
@@ -28,7 +28,7 @@ runs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 

--- a/build-python-package/action.yml
+++ b/build-python-package/action.yml
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2022-2024 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/build-python-package/action.yml
+++ b/build-python-package/action.yml
@@ -30,7 +30,7 @@ runs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install pypa/build
         shell: bash

--- a/publish-package/action.yml
+++ b/publish-package/action.yml
@@ -28,7 +28,7 @@ inputs:
     default: "./artifact"
   test_pypi:
     description: "Parameter to publish the package to Test PyPI when set to 'true', and to publish to official Pypi when set to 'false'."
-    default: "false"
+    required: true
 
 runs:
     using: composite

--- a/publish-package/action.yml
+++ b/publish-package/action.yml
@@ -28,7 +28,7 @@ inputs:
     default: "./artifact"
   test_pypi:
     description: "Parameter to publish the package to Test PyPI when set to 'true', and to publish to official Pypi when set to 'false'."
-    required: true
+    default: true
 
 runs:
     using: composite

--- a/publish-package/action.yml
+++ b/publish-package/action.yml
@@ -28,7 +28,7 @@ inputs:
     default: "./artifact"
   test_pypi:
     description: "Parameter to publish the package to Test PyPI when set to 'true', and to publish to official Pypi when set to 'false'."
-    default: true
+    default: 'true'
 
 runs:
     using: composite

--- a/publish-package/action.yml
+++ b/publish-package/action.yml
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2022-2024 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test-package/action.yml
+++ b/test-package/action.yml
@@ -46,7 +46,7 @@ runs:
         working-directory: ${{ inputs.working_directory }}
         run: >-
           python -m
-          pip install
+          pip install --no-deps 
           -r ./lock/requirements-dev.txt
 
       - name: Run pytest on freshly installed package

--- a/test-package/action.yml
+++ b/test-package/action.yml
@@ -46,7 +46,7 @@ runs:
         working-directory: ${{ inputs.working_directory }}
         run: >-
           python -m
-          pip install --no-deps 
+          pip install
           -r ./lock/requirements-dev.txt
 
       - name: Run pytest on freshly installed package

--- a/test-package/action.yml
+++ b/test-package/action.yml
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2022-2024 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test-package/action.yml
+++ b/test-package/action.yml
@@ -29,7 +29,7 @@ runs:
     steps:
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python_version }}
 

--- a/verify-version-tag/action.yml
+++ b/verify-version-tag/action.yml
@@ -39,7 +39,7 @@ runs:
         run: |
           if [ -f "pyproject.toml" ]
           then
-            PKG_VER=$(python3.11 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+            PKG_VER=$(python3.12 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           else
             echo "pyproject.toml were found." >&2; exit 1
           fi

--- a/verify-version-tag/action.yml
+++ b/verify-version-tag/action.yml
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Universität Tübingen, DKFZ and EMBL
+# Copyright 2022-2024 Universität Tübingen, DKFZ and EMBL
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verify-version-tag/action.yml
+++ b/verify-version-tag/action.yml
@@ -30,9 +30,9 @@ runs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Verify package version vs tag version
         shell: bash
         working-directory: ${{ inputs.working_directory }}


### PR DESCRIPTION
This PR introduces a reusable `pypi_publish` workflow encompassing all necessary steps to validate the package version tag, build, test, and publish it. The workflow will be invoked by the GHGA CLI tools. Centralizing this workflow in a single repository ensures that any updates are automatically reflected across CLI tools, minimizing redundancy.

This update primarily focuses on integrating the workflow without significant changes to individual actions approved previously, except for upgrading the Python version.

Please note that automatic detection of all supported Python versions from the pyproject.toml file for package testing is not in the scope of this PR.